### PR TITLE
Adding ping endpoint

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -107,6 +107,12 @@ def call_openai_api(prompt, role, isStream, model=""):
 api = Blueprint("api", __name__)
 
 
+@api.route("/api/ping", methods=["GET"])
+@query_params()
+def ping():
+    return jsonify({"pong": True}), 200
+
+
 @api.route("/api/generate-ideas", methods=["POST"])
 @query_params()
 def generate_ideas(source_code, stream=True):

--- a/app/decorators.py
+++ b/app/decorators.py
@@ -14,11 +14,6 @@ def query_params():
         @wraps(f)
         def wrapped(*args, **kwargs):
             payload = request.get_json(silent=True)
-
-            is_ping = payload.get("ping", False)
-            if is_ping:
-                return jsonify({"pong": True}), 200
-
             params = {name: payload.get(snake_to_camel(name), param.default) for name, param in parameters.items()}
 
             if not all(v is not None for v in params.values()):


### PR DESCRIPTION
Instead of managing it with a decorator and a payload field, we'll expose a `ping` endpoint to check api status.